### PR TITLE
Release 0.0.2 (since 0.0.1 was unpublished long time ago)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "garson",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "main": "dist/index.js",
   "bin": "dist/bin/index.js",
   "files": [


### PR DESCRIPTION
```
$ npm publish
npm ERR! publish Failed PUT 400
npm ERR! code E400
npm ERR! Cannot publish over previously published version "0.0.1". : garson

npm ERR! A complete log of this run can be found in:
npm ERR!     /Users/goliney/.npm/_logs/2019-12-22T20_56_38_251Z-debug.log
```